### PR TITLE
Reimplement Calendar.daysInMonth

### DIFF
--- a/lib/calendar-base.js
+++ b/lib/calendar-base.js
@@ -142,16 +142,7 @@ Calendar.interval = function ( date1, date2 ) {
 };
 
 Calendar.daysInMonth = function ( year, month ) {
-	// -1? It's December if considering January - 1!
-	if ( month == -1 || month == 0 || month == 2 || month == 4 || month == 6 || month == 7 || month == 9 || month == 11 ) {
-		return 31;
-	}
-	else if ( month == 3 || month == 5 || month == 8 || month == 10 ) {
-		return 30;
-	}
-	else if ( month == 1 ) {
-		return 28 + Calendar.isLeapYear( year );
-	}
+	return new Date(year, month + 1, 0).getDate();
 };
 
 Calendar.isLeapYear = function ( year ) {

--- a/test/index.js
+++ b/test/index.js
@@ -127,4 +127,11 @@ describe( 'calendar-base', function ( ) {
 		done();
 	} );
 
+	it ( 'should return valid days in month', function( done ) {
+		assert.equal( Calendar.daysInMonth( 1988, 1 ), 29 );
+		assert.equal( Calendar.daysInMonth( 1988, 7 ), 31 );
+		assert.equal( Calendar.daysInMonth( 2015, 10 ), 30 );
+		done();
+	} );
+
 } );


### PR DESCRIPTION
Thought it'd be simpler to rely on the built-in for Calendar.daysInMonth instead of hardcoding them. This way also allows for any relative month instead of only -1 for the previous December. I also added a test for it. I hope this is helpful. Thanks!
