### PR TITLE
Make the options an interface and export it

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,33 @@ export interface CalendarDate {
   year: number;
 }
 
+export interface CalendarOptions {
+  /**
+   * Date object indicating the selected start date
+   */
+  startDate?: CalendarDate | null;
+
+  /**
+   * Date object indicating the selected end date
+   */
+  endDate?: CalendarDate | null;
+
+  /**
+   * Calculate dates from sibling months (before and after the current month, based on weekStart)
+   */
+  siblingMonths?: boolean;
+
+  /**
+   * Calculate the week days
+   */
+  weekNumbers?: boolean;
+
+  /**
+   * Day of the week to start the calendar, respects `Date.prototype.getDay` (defaults to `0`, Sunday)
+   */
+  weekStart?: number;
+}
+
 /**
  * Calendar object
  */
@@ -29,32 +56,7 @@ class Calendar {
     siblingMonths = false,
     weekNumbers = false,
     weekStart = 0,
-  }: {
-    /**
-     * Date object indicating the selected start date
-     */
-    startDate?: CalendarDate | null;
-
-    /**
-     * Date object indicating the selected end date
-     */
-    endDate?: CalendarDate | null;
-
-    /**
-     * Calculate dates from sibling months (before and after the current month, based on weekStart)
-     */
-    siblingMonths?: boolean;
-
-    /**
-     * Calculate the week days
-     */
-    weekNumbers?: boolean;
-
-    /**
-     * Day of the week to start the calendar, respects `Date.prototype.getDay` (defaults to `0`, Sunday)
-     */
-    weekStart?: number;
-  } = {}) {
+  }: CalendarOptions = {}) {
     this.startDate = startDate;
     this.endDate = endDate;
     this.siblingMonths = siblingMonths;


### PR DESCRIPTION
It's not impossible you'd want to extend the calendar class, or wrap it or what ever, and thus extend the options. As it were that was impossible since the options type was inlined in the argument.

Consider: 

```ts
export type MyOptions = CalendarOptions & {
  multiple: boolean
  onDisplay(cal: Calendar): void
}

class MyCalendarWidget {
  constructor(options: MyOptions) {
    // ...
  }
}
```